### PR TITLE
[REFACTOR] #42 - Auth API Refactoring

### DIFF
--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Client/AuthClient.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Client/AuthClient.swift
@@ -1,0 +1,50 @@
+//
+//  AppleClient.swift
+//  dnd-12th-2-iOS
+//
+//  Created by 권석기 on 2/16/25.
+//
+
+import Foundation
+import ComposableArchitecture
+import AuthenticationServices
+import Moya
+
+struct AuthClient {
+    var signIn: (String) async throws -> AppleLoginResDto
+    var signOut: () async throws -> Void
+    
+    static let provider = MoyaProvider<AuthAPI>(session: Session(interceptor: AuthIntercepter.shared), plugins: [MoyaLoggingPlugin()])
+}
+
+extension AuthClient: DependencyKey {
+    static let liveValue = Self (
+        signIn: { idToken in
+            do {
+                let result: BaseResponse<AppleLoginResDto> = try await provider.async.request(.appleLogin(.init(code: idToken, deviceToken: "deviceToken")))
+                guard let result = result.data else {
+                    throw APIError.parseError
+                }
+                return result
+            } catch {
+                print(error.localizedDescription)
+                throw error
+            }
+        },
+        signOut: {
+            do {
+                try await provider.async.requestPlain(.logout)
+            } catch {
+                print(error.localizedDescription)
+                throw error
+            }
+        }
+    )
+}
+
+extension DependencyValues {
+    var authClient: AuthClient {
+        get { self[AuthClient.self] }
+        set { self[AuthClient.self] = newValue }
+    }
+}

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Navigation.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Navigation.swift
@@ -45,7 +45,7 @@ struct Navigation {
                 state = .loggedIn(.init())
                 return .none
                 // 마이페이지 로그아웃시
-            case .loggedIn(.path(.element(id: _, action: .myPage(.logoutButtonTapped)))):
+            case .loggedIn(.path(.element(id: _, action: .myPage(.logoutComplete)))):
                 state = .loggedOut(.init())
                 return .none
                 // 온보딩 완료된경우 메인으로 이동

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Navigation.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Navigation.swift
@@ -48,6 +48,14 @@ struct Navigation {
             case .loggedIn(.path(.element(id: _, action: .myPage(.logoutButtonTapped)))):
                 state = .loggedOut(.init())
                 return .none
+                // 온보딩 완료된경우 메인으로 이동
+            case .loggedOut(.goToMain):
+                state = .loggedIn(.init())
+                return .none
+                // 온보딩 미완료시 온보딩으로 이동
+            case .loggedOut(.goToOnboarding):
+                state = .loggedOut(.init(isOnboarding: true))                
+                return .none
             default:
                 return .none
             }

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Login/LoginView.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Login/LoginView.swift
@@ -7,21 +7,52 @@
 
 import SwiftUI
 import ComposableArchitecture
+import AuthenticationServices
 
 struct LoginView: View {
     @Perception.Bindable var store: StoreOf<LoginNavigation>
     var body: some View {
         WithPerceptionTracking {
             NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
-                VStack {
-                    Text("로그인뷰")
-                        .font(.title)
-                    Button(action: {
-                        store.send(.loginButtonTapped)
-                    }, label: {
-                        Text("Login")
-                    })
+                ZStack(alignment: .bottom) {
+                    Image("imgBackground")
+                    
+                    VStack {
+                        Text("빠르게 실패하세요. \n그리고 \n도달과 함께 개선하세요.")
+                            .headingStyle2()
+                            .alignmentLeading()
+                            .foregroundStyle(Color.gray900)
+                            .padding(.top, 77)
+                        
+                        Spacer()
+                        
+                        DDButton(image: Image("iconApple"),
+                                 imageSize: 20,
+                                 title: "애플 로그인",
+                                 font: .pretendard(size: 16, weight: .medium),
+                                 backgroundColor: .black,
+                                 cornerRadius: 8) {}
+                            .overlay {
+                                SignInWithAppleButton(
+                                    onRequest: { request in
+                                        request.requestedScopes = [.fullName, .email]},
+                                    onCompletion: { result in
+                                        switch result {
+                                        case let .success(authorization):
+                                            store.send(.appleLoginButtonTapped(authorization))
+                                            break
+                                        case .failure:
+                                            break
+                                        }
+                                    }
+                                )
+                                .blendMode(.overlay)
+                            }
+                            .padding(.bottom, 53)
+                    }
+                    .padding(.horizontal, 20)
                 }
+                .ignoresSafeArea(.container, edges: .bottom)
             } destination: { store in
                 switch store.case {
                 case let .complete(store):
@@ -31,7 +62,7 @@ struct LoginView: View {
                 case let .goal(store):
                     GoalView(store: store)
                 case let .goalComplete(store):
-                    GoalCompleteView(store: store)            
+                    GoalCompleteView(store: store)
                 }
             }
         }

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/MyPage/MyPage.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/MyPage/MyPage.swift
@@ -13,15 +13,25 @@ struct MyPage {
     
     enum Action {
         case logoutButtonTapped
+        case logoutComplete
     }
+    
+    @Dependency(\.authClient) var authClient
     
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
-                default:
-                    return .none
+            case .logoutButtonTapped:
+                return .run { send in
+                    try await authClient.signOut()                    
+                    await send(.logoutComplete)
                 }
+            case .logoutComplete:
+                KeyChainManager.deleteItem(key: .accessToken)
+                KeyChainManager.deleteItem(key: .refreshToken)
+                return .none
             }
         }
     }
+}
 

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/dnd_12th_2_iOSApp.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/dnd_12th_2_iOSApp.swift
@@ -18,8 +18,12 @@ struct dnd_12th_2_iOSApp: App {
                 Navigation()
             }))
             .onAppear {
-                KeyChainManager.addItem(key: .accessToken, value: SecretKey.apiKey)
-                KeyChainManager.addItem(key: .refreshToken, value: SecretKey.apiKey)
+                // 토큰 지울때 사용
+//                KeyChainManager.deleteItem(key: .accessToken)
+//                KeyChainManager.deleteItem(key: .refreshToken)
+                // 테스트유저 토큰
+//                KeyChainManager.addItem(key: .accessToken, value: SecretKey.apiKey)
+//                KeyChainManager.addItem(key: .refreshToken, value: SecretKey.apiKey)
             }
         }
     }


### PR DESCRIPTION
##  🚀 Description
Auth API Refactoring 진행
##  ✅ PR Point
- 온보딩을 완료하지 않고 로그인시 예외처리
- MyPage에서 로그아웃 API 연동

### 온보딩 미완료시 로그인
온보딩을 완료하지 않고 앱을 삭제한뒤에 재로그인 하는경우 기존 로직은 유저정보가 존재하는 경우만 판단하고 홈으로 이동하는 문제가 있었습니다. 
- 로그인이 완료되고 한번 더 온보딩 완료여부를 체크하는 로직을 추가했습니다.
- KeyChain에 토큰을 저장하고 요청하기 위해서 concatenate를 활용해 봤습니다.
- 첫번째 로그인 요청이 실패하는 경우 다음 로직은 수행되지 않습니다.
```swift
 // TODO: 로그인한 유저 온보딩 완료여부 확인 처리            
                return .concatenate([
                    .run { send in
                        let result = try await authClient.signIn(IdentityToken)
                        await send(.appleLoginComplete(result))
                    },
                    .run { send in
                        let _ = try await userClient.fetchUserOnboarding()
                        await send(.goToMain)
                    } catch: { error, send in
                        // 온보딩 데이터가 없는 경우 예외가 발생한다
                        await send(.goToOnboarding)
                    }
                ])
```

### known issue
온보딩 완료여부를 요청하는 API가 온보딩 데이터가 없는경우 무조건 에러를 응답하기 때문에 에러가 나는경우 온보딩으로 이동하도록 했습니다. BE 분들과 이야기를 해보고 데이터가 없는 경우에도 값을 내려달라고 말씀드려볼까 생각중입니다.
## 📸 Screenshot

|뷰|설명|
|------|---|
|      |    |


## 📌 Related Issue

- Resolved: #42 
