### PR TITLE
[FIX] #60 - Onboarding API 변경사항 대응

### DIFF
--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Client/UserClient.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Client/UserClient.swift
@@ -20,8 +20,11 @@ extension UserClient: DependencyKey {
     static let liveValue = Self (
         fetchUserOnboarding: {
             do {
-                try await provider.async.requestPlain(.meOnboarding)
-                return true
+                let result: BaseResponse<UserOnboardingResDto> = try await provider.async.request(.meOnboarding)
+                guard let data = result.data else {
+                    throw APIError.parseError
+                }
+                return data.checkOnboardingDone
             } catch {
                 throw error
             }

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Model/Plan.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Model/Plan.swift
@@ -22,7 +22,7 @@ struct Plan: Hashable {
     let completedDate: String?
     
     var period: String {
-        return "\(startDate.toTimeFormat(inputFormat: "yyyy-MM-dd")) ~ \(endDate.toTimeFormat(inputFormat: "yyyy-MM-dd"))"
+        return "\(startDate.toTimeFormat()) ~ \(endDate.toTimeFormat())"
     }
     
     var resultType: ResultType {

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Network/DTO/UserOnboardingResDto.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Network/DTO/UserOnboardingResDto.swift
@@ -1,0 +1,16 @@
+//
+//  UserOnboardingResDto.swift
+//  dnd-12th-2-iOS
+//
+//  Created by 권석기 on 3/8/25.
+//
+
+struct UserOnboardingResDto: Decodable {
+    let checkOnboardingDone: Bool
+    let data: [UserAnswerResDto]
+}
+
+struct UserAnswerResDto: Decodable {
+    let questionContent: String
+    let answerContent: String
+}

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Login/LoginNavigation.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Login/LoginNavigation.swift
@@ -76,8 +76,12 @@ struct LoginNavigation {
                         await send(.appleLoginComplete(result))
                     },
                     .run { send in
-                        let _ = try await userClient.fetchUserOnboarding()
-                        await send(.goToMain)
+                        let isOnboarding = try await userClient.fetchUserOnboarding()
+                        if isOnboarding {
+                            await send(.goToMain)
+                        } else {
+                            await send(.goToOnboarding)
+                        }                        
                     } catch: { error, send in
                         // 온보딩 데이터가 없는 경우 예외가 발생한다
                         await send(.goToOnboarding)

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Splash/LoginCheck.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Splash/LoginCheck.swift
@@ -29,24 +29,18 @@ struct LoginCheck {
             switch action {
             case .loginCheck:
                 // 온보딩 완료여부 체크
-                let isLogin = KeyChainManager.readItem(key: .accessToken) != nil && KeyChainManager.readItem(key: .refreshToken) != nil
                 return .run { send in
-                    // TODO: 단순히 온보딩 데이터가 없는경우 예외처리
                     let isOnboarding = try await userClient.fetchUserOnboarding()
                     
-                    if isOnboarding && isLogin {
+                    // 온보딩성공시
+                    if isOnboarding {
                         await send(.onboardingComplete)
-                    } else if isLogin {
+                    } else if !isOnboarding {
                         await send(.loginComplete)
-                    } else {
-                        await send(.loginNotComplete)
                     }
                 } catch: { error, send in
-                    if isLogin {
-                        await send(.loginComplete)
-                    } else {
-                        await send(.loginNotComplete)
-                    }
+                    // 토큰이 유효하지 않거나 다른문제 발생시
+                    await send(.loginNotComplete)
                 }
             default:
                 return .none

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/dnd_12th_2_iOSApp.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/dnd_12th_2_iOSApp.swift
@@ -19,11 +19,11 @@ struct dnd_12th_2_iOSApp: App {
             }))
             .onAppear {
                 // 토큰 지울때 사용
-                KeyChainManager.deleteItem(key: .accessToken)
-                KeyChainManager.deleteItem(key: .refreshToken)
+//                KeyChainManager.deleteItem(key: .accessToken)
+//                KeyChainManager.deleteItem(key: .refreshToken)
                //  테스트유저 토큰
-                KeyChainManager.addItem(key: .accessToken, value: SecretKey.apiKey)
-                KeyChainManager.addItem(key: .refreshToken, value: SecretKey.apiKey)
+//                KeyChainManager.addItem(key: .accessToken, value: SecretKey.apiKey)
+//                KeyChainManager.addItem(key: .refreshToken, value: SecretKey.apiKey)
             }
         }
     }


### PR DESCRIPTION
##  🚀 Description
온보딩데이터가 없는경우 무조건 예외를 발생시키는 문제를 해결
##  ✅ PR Point
- Onboarding API 변경사항에 대응합니다.
## 📸 Screenshot
기존에는 온보딩데이터가 없는경우 무조건 예외를 발생시키기 때문에 온보딩데이터가 없는경우와 다른 외부적인 예외상황을 구분하지 못하는 문제가 있었습니다.
서버에서 온보딩 데이터가 없더라도 정상적으로 응답을 내려주도록 수정하고 이에 대응하여 일부 로직이 변경되었습니다.

### LoginCheck 로직 변경
```swift
  return .run { send in
                    let isOnboarding = try await userClient.fetchUserOnboarding()
                    
                    // 온보딩성공시
                    if isOnboarding {
                        await send(.onboardingComplete)
                    } else if !isOnboarding {
                        await send(.loginComplete)
                    }
                } catch: { error, send in
                    // 토큰이 유효하지 않거나 다른문제 발생시
                    await send(.loginNotComplete)
                }
```
기존에는 토큰이 유효하더라도 온보딩 데이터가 없는경우 무조건 예외처리로 구분이 되었는데 변경후에 온보딩 데이터가 없는경우와 기타적인 예외상황을 명확하게 처리할 수 있도록 로직을 변경했습니다. 
추가적으로 헤더에 토큰이 존재하지 않거나 유효하지 않다면 에러를 반환하기 때문에 KeyChain에서 토큰유무를 검사하는 부분은 제거했습니다.

|뷰|설명|
|------|---|
|      |    |


## 📌 Related Issue

- Resolved: #60 
