### PR TITLE
[FEAT] #76 - 목표삭제 기능 추가

### DIFF
--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Client/GoalClient.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Client/GoalClient.swift
@@ -13,6 +13,7 @@ struct GoalClient {
     var makeGoal: (GoalInfo) async throws -> Void
     var makePlan: (Int, PlanInfo) async throws -> Void
     var fetchGoal: () async throws -> [Goal]
+    var deleteGoal: (Int) async throws -> Void
     var fetchWeeklyGoal: (Int, String) async throws -> [Day]
     var fetchPlans: (Int, String, Int) async throws -> [Plan]
     var achieveGoal: (Int) async throws -> Void
@@ -43,6 +44,12 @@ extension GoalClient: DependencyKey {
                     throw APIError.parseError
                 }
                 return result.toDomain()
+            } catch {
+                throw error
+            }
+        } , deleteGoal: { goalId in
+            do {
+                try await provider.async.requestPlain(.deleteGoal(goalID: goalId))                
             } catch {
                 throw error
             }

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Network/API/GoalAPI.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Network/API/GoalAPI.swift
@@ -11,6 +11,7 @@ import Moya
 enum GoalAPI {
     case makeGoalWithPlan(GoalReqDto)
     case makePlan(goalID: Int, planReqDto: PlanRequestDto)
+    case deleteGoal(goalID: Int)
     case fetchGoal
     case fetchWeeklyGoal(Int, String)
     case fetchPlans(goalId: Int, date: String, range: Int)
@@ -37,6 +38,8 @@ extension GoalAPI: TargetType {
             return "/\(goalId)/achieve"
         case let .fetchSuccessRate(goalId):
             return "/\(goalId)/statistics"
+        case let .deleteGoal(goalID):
+            return "/\(goalID)"
         default:
             return ""
         }
@@ -58,6 +61,8 @@ extension GoalAPI: TargetType {
             return .patch
         case .fetchSuccessRate:
             return .get
+        case .deleteGoal:
+            return .delete
         }
     }
     

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Main/Home/HomeNavigation.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Main/Home/HomeNavigation.swift
@@ -16,6 +16,7 @@ struct HomeNavigation {
         var isShowMenu = false
         var isShowGoalList = false
         var isCustomAlertPresented = false
+        var isShowDeleteAlert = false
         var calendar: MakeCalendar.State
         var fetchPlan: FetchPlan.State
         let goalTitle: String
@@ -62,6 +63,10 @@ struct HomeNavigation {
         case customAlertDismissed
         case confirmButtonTapped
         case achieveGoal(goalId: Int)
+        case showDeleteAlert
+        case showDeleteAlertDismissed
+        case deleteGoal
+        case deleteGoalCompleted
     }
     
     @Dependency(\.goalClient) var goalClient
@@ -84,6 +89,17 @@ struct HomeNavigation {
                 return .none
             case .addPlanButtonTapped:
                 return .send(.goToSetPlan(goalId: state.goalId))
+            case .showDeleteAlert:                
+                state.isShowDeleteAlert = true
+                return .none
+            case .showDeleteAlertDismissed:
+                state.isShowDeleteAlert = false
+                return .none
+            case .deleteGoal:
+                return .run { [state] send in
+                    try await goalClient.deleteGoal(state.goalId)
+                    await send(.deleteGoalCompleted)
+                }
                 // MARK: - FetchPlan
             case .fetchPlan(.cellTapped):
                 if let planInfo = state.fetchPlan.plan, planInfo.resultType == .ready {

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Main/Home/HomeView.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Main/Home/HomeView.swift
@@ -41,6 +41,21 @@ struct HomeView: View {
                     )
                 }
             })
+            .overlay(alignment: .center, content: {
+                if store.state.isShowDeleteAlert {
+                    DDAlert(
+                        title: "할 일을 정말 삭제할까요?",
+                        cancelButtonTitle: "취소",
+                        confirmButtonTitle: "삭제",
+                        onCancel: {
+                            store.send(.showDeleteAlertDismissed)
+                        },
+                        onConfirm: {
+                            store.send(.deleteGoal)
+                        }
+                    )
+                }
+            })
             .overlay(alignment: .bottomTrailing, content: {
                 CTAButton(isScrolling: isScrolling) {
                     store.send(.addPlanButtonTapped)
@@ -128,6 +143,10 @@ extension HomeView {
                     }
                     Spacer()
                     Image("iconGray")
+                }
+                .onTapGesture {
+                    store.send(.showDeleteAlert)
+                    store.send(.hideMenu)
                 }
             }
             .padding(.vertical, 14.5)

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Main/Home/HomeView.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Main/Home/HomeView.swift
@@ -44,7 +44,7 @@ struct HomeView: View {
             .overlay(alignment: .center, content: {
                 if store.state.isShowDeleteAlert {
                     DDAlert(
-                        title: "할 일을 정말 삭제할까요?",
+                        title: "목표를 정말 삭제할까요?",
                         cancelButtonTitle: "취소",
                         confirmButtonTitle: "삭제",
                         onCancel: {

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Main/MainNavigation.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Main/MainNavigation.swift
@@ -71,6 +71,9 @@ struct MainNavigation {
                 case let .element(id: id, action: .home(.backButtonTapped)):
                     state.path.pop(from: id)
                     return .none
+                case let .element(id: id, action: .home(.deleteGoalCompleted)):
+                    state.path.pop(from: id)
+                    return .none
                 case let .element(id: id, action: .setGoal(.requestRemoveFromStack)):
                     state.path.pop(from: id)
                     return .none


### PR DESCRIPTION
##  🚀 Description
목표 삭제 기능을 추가했습니다.
##  ✅ PR Point
- GoalClient에 DeleteGoal 메서드 추가
- 목표 삭제 관련 Endpoint 추가
- 목표 삭제시 화면스택 제거
## 📸 Screenshot

|뷰|설명|
|------|---|
|      |    |


## 📌 Related Issue

- Resolved: #76 
