### PR TITLE
[FIX] #94 - 로그인화면 Image가 잘리는 문제 수정

### DIFF
--- a/dnd-12th-2-iOS/dnd-12th-2-iOS.xcodeproj/project.pbxproj
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS.xcodeproj/project.pbxproj
@@ -7,18 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		478670702D719112005216CF /* Secrets-prod.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4786706F2D719112005216CF /* Secrets-prod.xcconfig */; };
-		478670722D71911D005216CF /* Secrets-dev.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 478670712D71911D005216CF /* Secrets-dev.xcconfig */; };
 		47F57E892D6205AB0043983D /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 47F57E882D6205AB0043983D /* CombineMoya */; };
 		47F57E8B2D6205AB0043983D /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 47F57E8A2D6205AB0043983D /* Moya */; };
 		47F57E8D2D6205AB0043983D /* ReactiveMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 47F57E8C2D6205AB0043983D /* ReactiveMoya */; };
 		47F57E8F2D6205AB0043983D /* RxMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 47F57E8E2D6205AB0043983D /* RxMoya */; };
+		47FBF6472D9A54CD008AD7F6 /* Secrets-dev.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 47FBF6462D9A54CD008AD7F6 /* Secrets-dev.xcconfig */; };
+		47FBF6492D9A54D3008AD7F6 /* Secrets-prod.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 47FBF6482D9A54D3008AD7F6 /* Secrets-prod.xcconfig */; };
 		FB8E733C2D40CCCB005F935D /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = FB8E733B2D40CCCB005F935D /* ComposableArchitecture */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		4786706F2D719112005216CF /* Secrets-prod.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Secrets-prod.xcconfig"; sourceTree = "<group>"; };
-		478670712D71911D005216CF /* Secrets-dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Secrets-dev.xcconfig"; sourceTree = "<group>"; };
+		47FBF6462D9A54CD008AD7F6 /* Secrets-dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Secrets-dev.xcconfig"; sourceTree = "<group>"; };
+		47FBF6482D9A54D3008AD7F6 /* Secrets-prod.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Secrets-prod.xcconfig"; sourceTree = "<group>"; };
 		FB8E73282D40CB60005F935D /* dnd-12th-2-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "dnd-12th-2-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -64,8 +64,8 @@
 		FB8E731F2D40CB60005F935D = {
 			isa = PBXGroup;
 			children = (
-				478670712D71911D005216CF /* Secrets-dev.xcconfig */,
-				4786706F2D719112005216CF /* Secrets-prod.xcconfig */,
+				47FBF6462D9A54CD008AD7F6 /* Secrets-dev.xcconfig */,
+				47FBF6482D9A54D3008AD7F6 /* Secrets-prod.xcconfig */,
 				FB8E732A2D40CB60005F935D /* dnd-12th-2-iOS */,
 				FB8E73292D40CB60005F935D /* Products */,
 			);
@@ -152,8 +152,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				478670722D71911D005216CF /* Secrets-dev.xcconfig in Resources */,
-				478670702D719112005216CF /* Secrets-prod.xcconfig in Resources */,
+				47FBF6492D9A54D3008AD7F6 /* Secrets-prod.xcconfig in Resources */,
+				47FBF6472D9A54CD008AD7F6 /* Secrets-dev.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,7 +172,7 @@
 /* Begin XCBuildConfiguration section */
 		FB8E73342D40CB63005F935D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 478670712D71911D005216CF /* Secrets-dev.xcconfig */;
+			baseConfigurationReference = 47FBF6462D9A54CD008AD7F6 /* Secrets-dev.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -236,7 +236,7 @@
 		};
 		FB8E73352D40CB63005F935D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4786706F2D719112005216CF /* Secrets-prod.xcconfig */;
+			baseConfigurationReference = 47FBF6482D9A54D3008AD7F6 /* Secrets-prod.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -293,7 +293,7 @@
 		};
 		FB8E73372D40CB63005F935D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 478670712D71911D005216CF /* Secrets-dev.xcconfig */;
+			baseConfigurationReference = 47FBF6462D9A54CD008AD7F6 /* Secrets-dev.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -339,7 +339,7 @@
 		};
 		FB8E73382D40CB63005F935D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4786706F2D719112005216CF /* Secrets-prod.xcconfig */;
+			baseConfigurationReference = 47FBF6482D9A54D3008AD7F6 /* Secrets-prod.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Login/LoginView.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Login/LoginView.swift
@@ -22,18 +22,25 @@ struct LoginView: View {
                         VStack(spacing: 0) {
                             Spacer()
                            Image("onboardingImage1")
+                                .resizable()
+                                    .scaledToFit()
                         }
                         .tag(0)
                         
                         VStack(spacing: 0) {
                             Spacer()
                             Image("onboardingImage2")
+                                .resizable()
+                                    .scaledToFit()
                         }
                         .tag(1)
                         
                         VStack(spacing: 0) {
                             Spacer()
                             Image("onboardingImage3")
+                                .resizable()
+                                    .scaledToFit()
+                            
                         }
                         .tag(2)
                     }


### PR DESCRIPTION
##  🚀 Description
iPad 화면에서 이미지 잘리는 문제를 수정했습니다.
##  ✅ PR Point
- iPad가 아닌 일반 디바이스도 확인했습니다.
## 📸 Screenshot

|뷰|설명|
|------|---|
|      |    |


## 📌 Related Issue

- Resolved: #94 
