### PR TITLE
[FEAT] #106 - Setting View

### DIFF
--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/MainTab/MainTabView.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/MainTab/MainTabView.swift
@@ -23,7 +23,9 @@ struct MainTabView: View {
                     TodoView()
                         .tag(TabInfo.todo)
                     
-                    SettingView()
+                    SettingView(store: .init(initialState: SettingFeature.State(), reducer: {
+                        SettingFeature()
+                    }))
                         .tag(TabInfo.setting)
                     
                 }

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Settings/SettingFeature.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Settings/SettingFeature.swift
@@ -1,0 +1,36 @@
+//
+//  SettingFeature.swift
+//  dnd-12th-2-iOS
+//
+//  Created by Allie on 5/18/25.
+//
+
+import Foundation
+
+import ComposableArchitecture
+
+@Reducer
+struct SettingFeature {
+    @ObservableState
+    struct State {
+        var isShowWebView = false
+    }
+    
+    enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        case showWebView
+    }
+        
+    var body: some Reducer<State, Action> {
+        BindingReducer()
+        Reduce { state, action in
+            switch action {
+            case .showWebView:
+                state.isShowWebView = true
+                return .none
+            default:
+                return .none
+            }
+        }
+    }
+}

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Settings/SettingView.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Settings/SettingView.swift
@@ -7,12 +7,48 @@
 
 import SwiftUI
 
-struct SettingView: View {
-    var body: some View {
-        Text("SettingView")
-    }
-}
+import ComposableArchitecture
 
-#Preview {
-    SettingView()
+struct SettingView: View {
+    @Perception.Bindable var store: StoreOf<SettingFeature>
+    
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                HStack {
+                    Text("설정")
+                        .font(.pretendard(size: 16, weight: .bold))
+                        .foregroundStyle(.gray900)
+                }
+                .padding(.top, 16)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 8)
+                
+                Button(action: {
+                    store.send(.showWebView)
+                }) {
+                    Text("1:1 문의")
+                        .font(.pretendard(size: 16, weight: .semibold))
+                        .foregroundStyle(.gray900)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.vertical, 16)
+                        .padding(.horizontal, 16)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.gray0)
+                        )
+                        .padding(.horizontal, 16)
+                        .padding(.top, 38)
+                }
+                
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.gray50)
+            .sheet(isPresented: $store.isShowWebView) {
+                WebView(url: "https://www.instagram.com/dodal_in_ur_goal?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==")
+                    .edgesIgnoringSafeArea(.all)
+            }
+        }
+    }
 }

--- a/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Settings/WebView.swift
+++ b/dnd-12th-2-iOS/dnd-12th-2-iOS/Presentation/Settings/WebView.swift
@@ -1,0 +1,30 @@
+//
+//  WebView.swift
+//  dnd-12th-2-iOS
+//
+//  Created by Allie on 5/18/25.
+//
+
+import SwiftUI
+import WebKit
+
+struct WebView: UIViewRepresentable {
+    var url: String
+    
+    func makeUIView(context: Context) -> WKWebView {
+        guard let url = URL(string: url) else {
+            return WKWebView()
+        }
+        let webView = WKWebView()
+
+        webView.load(URLRequest(url: url))
+        
+        return webView
+    }
+    
+    func updateUIView(_ webView: WKWebView, context: UIViewRepresentableContext<WebView>) {
+        guard let url = URL(string: url) else { return }
+        
+        webView.load(URLRequest(url: url))
+    }
+}


### PR DESCRIPTION
##  🚀 Description
Setting View를 추가했습니다.
기존 버전과 동일하게 1:1문의시 도달의 SNS계정을 웹뷰로 보여주도록 연결했습니다.
현재로서는 해당 기능만 있어서 추후에 다른 기능이 추가된다면 추가 작업하도록 하겠습니다.

## 📸 Screenshot
![simulator_screenshot_87749608-B2D0-48D9-B495-291D8877FBB1](https://github.com/user-attachments/assets/9a595c2d-413f-4dea-a69f-623a3219b4b6)


## 📌 Related Issue

- Resolved: #106 
